### PR TITLE
fixed set import

### DIFF
--- a/bin/nfasd
+++ b/bin/nfasd
@@ -7,7 +7,6 @@ import platform # to find XDG_DATA_HOME
 import operator
 import msgpack # to parse shada
 import re
-from sets import Set
 # from argcomplete import warn # logging
 
 def shada_path():
@@ -52,7 +51,7 @@ def nvim_oldfiles(shada_path):
   # 11 (Change)
   valid_types = [7, 8, 10, 11]
 
-  file_set = Set()
+  file_set = set()
   recent_files = []
 
   try:


### PR DESCRIPTION
Hi @haifengkao, Set.sets has been deprecated, which breaks nfasd on Python 3.6.

❯ n                                                         
Traceback (most recent call last):                                    
  File "/home/arcanjo/.local/bin/nfasd", line 9, in <module>       
    from sets import Set                                      
ModuleNotFoundError: No module named 'sets'                               
                                        
~/.dotfiles master*                                              
❯ python -V                                                   
Python 3.6.4    

This patch fixes this it. 

Thanks!


